### PR TITLE
fix: update Jekyll config for custom domain and gitignore _site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ venv.bak/
 # mkdocs documentation
 /site
 
+# Jekyll build output
+_site/
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 title: Open Responses Server
 description: >-
   A plug-and-play server that speaks OpenAI's Responses API—no matter which AI backend you're running.
-baseurl: "/open-responses-server"
-url: "https://teabranch.github.io"
+baseurl: ""
+url: "https://open-responses-server.teabranch.dev"
 
 theme: just-the-docs
 color_scheme: anthropic


### PR DESCRIPTION
## Summary

- Update `url` and `baseurl` in `_config.yml` to match the custom domain (`open-responses-server.teabranch.dev`). The old config pointed at `teabranch.github.io` with `baseurl: "/open-responses-server"`, which caused the sitemap to generate incorrect URLs (e.g., `https://teabranch.github.io/docs/SECURITY.html` instead of `https://open-responses-server.teabranch.dev/docs/SECURITY.html`).
- Add `_site/` to `.gitignore` to prevent Jekyll build output from being tracked.

## Test plan

- [ ] Verify `bundle exec jekyll build` generates correct sitemap URLs
- [ ] Verify GitHub Pages deployment produces correct sitemap after merge
- [ ] Verify `_site/` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude